### PR TITLE
Order terms by their period number

### DIFF
--- a/app/Http/Controllers/EducationController.php
+++ b/app/Http/Controllers/EducationController.php
@@ -39,6 +39,7 @@ class EducationController extends Controller
             {
                 $term = $cohort->terms()
                     ->whereBetween('order', [$education->terms_per_year*$i+1, $education->terms_per_year*$studyyear])
+                    ->orderBy('order')
                     ->get();
                 if(count($term))
                 {


### PR DESCRIPTION
The terms will be ordered by period rather than id and prevent HTML from being outputted in the wrong order.